### PR TITLE
Don't override accountOnFile setter in ICPaymentRequest

### DIFF
--- a/IngenicoConnectSDK/ICPaymentRequest.m
+++ b/IngenicoConnectSDK/ICPaymentRequest.m
@@ -95,14 +95,6 @@
     }
 }
 
-- (void)setAccountOnFile:(ICAccountOnFile *)accountOnFile
-{
-    _accountOnFile = accountOnFile;
-    for (ICAccountOnFileAttribute *attribute in accountOnFile.attributes.attributes) {
-        [self.fieldValues setObject:attribute.value forKey:attribute.key];
-    }
-}
-
 - (NSString *)maskForField:(NSString *)paymentProductFieldId
 {
     ICPaymentProductField *field = [self.paymentProduct paymentProductFieldWithId:paymentProductFieldId];


### PR DESCRIPTION
The attributes of the account on file may contain obfuscated values. We should not automatically assign them to the payment request.
The behavior is now the same as the one of the Android SDK ( https://github.com/Ingenico-ePayments/connect-sdk-client-android/blob/36c50f6627d817b0a2dae33a206cb21e40c5c894/globalcollect-sdk/src/main/java/com/globalcollect/gateway/sdk/client/android/sdk/model/PaymentRequest.java#L322-L333 ).